### PR TITLE
SLO Smart Alert resource support for Terraform

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,11 +22,6 @@ jobs:
         with:
           go-version: 1.20.0
 
-      - name: Set up GPG
-        run: |
-          export GPG_TTY=$(tty)
-          eval $(gpg-agent --daemon)
-
       - name: Import GPG key
         id: import_gpg
         uses: paultyng/ghaction-import-gpg@v2.1.0
@@ -38,7 +33,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v6
         with:
           version: "~> v2"
-          args: release --clean
+          args: release --rm-dist
         env:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -46,4 +46,5 @@ release:
   # If you want to manually examine the release before its live, uncomment this line:
   # draft: true
 changelog:
-  disable: false
+  skip: false
+  sort: asc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,6 @@
 # Changelog
 
-## [v3.1.1](https://github.com/instana/terraform-provider-instana/tree/v3.1.1) (2025-02-10)
-
-[Full Changelog](https://github.com/instana/terraform-provider-instana/compare/v3.1.0...v3.1.1)
-
-**Merged pull requests:**
-
-- Extend index.md with Infrastructure Alert Config [\#22](https://github.com/instana/terraform-provider-instana/pull/22) ([parekh-raj](https://github.com/parekh-raj))
-
-## [v3.1.0](https://github.com/instana/terraform-provider-instana/tree/v3.1.0) (2025-01-16)
+## [v3.1.0](https://github.com/instana/terraform-provider-instana/tree/v3.1.0) (2025-01-14)
 
 [Full Changelog](https://github.com/instana/terraform-provider-instana/compare/v3.0.1...v3.1.0)
 

--- a/instana/provider.go
+++ b/instana/provider.go
@@ -69,6 +69,7 @@ func providerResources() map[string]*schema.Resource {
 	bindResourceHandle(resources, NewAlertingConfigResourceHandle())
 	bindResourceHandle(resources, NewSliConfigResourceHandle())
 	bindResourceHandle(resources, NewSloConfigResourceHandle())
+	bindResourceHandle(resources, NewSloAlertConfigResourceHandle())
 	bindResourceHandle(resources, NewWebsiteMonitoringConfigResourceHandle())
 	bindResourceHandle(resources, NewInfraAlertConfigResourceHandle())
 	bindResourceHandle(resources, NewWebsiteAlertConfigResourceHandle())

--- a/instana/provider_test.go
+++ b/instana/provider_test.go
@@ -29,7 +29,7 @@ func TestProviderShouldContainValidSchemaDefinition(t *testing.T) {
 func TestProviderShouldContainValidResourceDefinitions(t *testing.T) {
 	config := Provider()
 
-	assert.Equal(t, 14, len(config.ResourcesMap))
+	assert.Equal(t, 15, len(config.ResourcesMap))
 
 	assert.NotNil(t, config.ResourcesMap[ResourceInstanaAPIToken])
 	assert.NotNil(t, config.ResourcesMap[ResourceInstanaApplicationConfig])
@@ -37,6 +37,7 @@ func TestProviderShouldContainValidResourceDefinitions(t *testing.T) {
 	assert.NotNil(t, config.ResourcesMap[ResourceInstanaGlobalApplicationAlertConfig])
 	assert.NotNil(t, config.ResourcesMap[ResourceInstanaSliConfig])
 	assert.NotNil(t, config.ResourcesMap[ResourceInstanaSloConfig])
+	assert.NotNil(t, config.ResourcesMap[ResourceInstanaSloAlertConfig])
 	assert.NotNil(t, config.ResourcesMap[ResourceInstanaWebsiteMonitoringConfig])
 	assert.NotNil(t, config.ResourcesMap[ResourceInstanaWebsiteAlertConfig])
 	assert.NotNil(t, config.ResourcesMap[ResourceInstanaInfraAlertConfig])

--- a/instana/resource-slo-alert-config.go
+++ b/instana/resource-slo-alert-config.go
@@ -25,7 +25,6 @@ const (
 	SloAlertConfigFieldTimeThreshold           = "time_threshold"
 	SloAlertConfigFieldTimeThresholdTimeWindow = "time_window"
 	SloAlertConfigFieldTimeThresholdExpiry     = "expiry"
-	SloAlertConfigFieldCustomPayloadFields     = "custom_payload_fields"
 	SloAlertConfigFieldEnabled                 = "enabled"
 
 	SloAlertConfigFieldBurnRateTimeWindows      = "burn_rate_time_windows"
@@ -216,7 +215,7 @@ var (
 			},
 		},
 	}
-	
+
 )
 
 func NewSloAlertConfigResourceHandle() ResourceHandle[*restapi.SloAlertConfig] {
@@ -224,17 +223,17 @@ func NewSloAlertConfigResourceHandle() ResourceHandle[*restapi.SloAlertConfig] {
 		metaData: ResourceMetaData{
 			ResourceName: ResourceInstanaSloAlertConfig,
 			Schema: map[string]*schema.Schema{
-				SloAlertConfigFieldName:          	SloAlertConfigName,
-				SloAlertConfigFieldDescription:     SloAlertConfigDescription,
-				SloAlertConfigFieldSeverity:        SloAlertConfigSeverity,
-				SloAlertConfigFieldTriggering:   	SloAlertConfigTriggering,
-				SloAlertConfigFieldAlertType:   	SloAlertConfigAlertType,
-				SloAlertConfigFieldThreshold:    	SloAlertConfigThreshold,
-				SloAlertConfigFieldSloIds:  		SloAlertConfigSloIds,
-				SloAlertConfigFieldAlertChannelIds: SloAlertConfigAlertChannelIds,
-				SloAlertConfigFieldTimeThreshold:   SloAlertConfigTimeThreshold,
-				DefaultCustomPayloadFieldsName:  	buildCustomPayloadFields(),
-				SloAlertConfigFieldEnabled: 		SloAlertConfigEnabled,
+				SloAlertConfigFieldName:          			SloAlertConfigName,
+				SloAlertConfigFieldDescription:     		SloAlertConfigDescription,
+				SloAlertConfigFieldSeverity:        		SloAlertConfigSeverity,
+				SloAlertConfigFieldTriggering:   			SloAlertConfigTriggering,
+				SloAlertConfigFieldAlertType:   			SloAlertConfigAlertType,
+				SloAlertConfigFieldThreshold:    			SloAlertConfigThreshold,
+				SloAlertConfigFieldSloIds:  				SloAlertConfigSloIds,
+				SloAlertConfigFieldAlertChannelIds: 		SloAlertConfigAlertChannelIds,
+				SloAlertConfigFieldTimeThreshold:   		SloAlertConfigTimeThreshold,
+				DefaultCustomPayloadFieldsName: 			buildCustomPayloadFields(),
+				SloAlertConfigFieldEnabled: 				SloAlertConfigEnabled,
 			},
 			SchemaVersion:    1,
 			CreateOnly:       false,
@@ -256,8 +255,7 @@ func (r *sloAlertConfigResource) MetaData() *ResourceMetaData {
 }
 
 func (r *sloAlertConfigResource) GetRestResource(api restapi.InstanaAPI) restapi.RestResource[*restapi.SloAlertConfig] {
-	x := api.SloAlertConfigs()
-	return x
+	return api.SloAlertConfig()
 }
 
 func (r *sloAlertConfigResource) SetComputedFields(_ *schema.ResourceData) error {
@@ -330,6 +328,7 @@ func (r *sloAlertConfigResource) UpdateState(d *schema.ResourceData, sloAlertCon
         SloAlertConfigFieldSloIds:        sloAlertConfig.SloIds,
         SloAlertConfigFieldAlertChannelIds: sloAlertConfig.AlertChannelIds,
         SloAlertConfigFieldTimeThreshold: []interface{}{timeThreshold},
+		DefaultCustomPayloadFieldsName:   mapCustomPayloadFieldsToSchema(sloAlertConfig),
         SloAlertConfigFieldEnabled:       sloAlertConfig.Enabled,
     }
 
@@ -371,11 +370,11 @@ func (r *sloAlertConfigResource) MapStateToDataObject(d *schema.ResourceData) (*
         }
     }
 
-    // Custom Payload Fields
-    customPayloadFields, err := mapDefaultCustomPayloadFieldsFromSchema(d)
-    if err != nil {
-        return &restapi.SloAlertConfig{}, err
-    }
+	// Custom Payload Fields
+	customPayloadFields, err := mapDefaultCustomPayloadFieldsFromSchema(d)
+	if err != nil {
+		return &restapi.SloAlertConfig{}, err
+	}
 
     // Construct API payload
     payload := &restapi.SloAlertConfig{

--- a/instana/resource-slo-alert-config.go
+++ b/instana/resource-slo-alert-config.go
@@ -1,0 +1,160 @@
+package instana
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+const ResourceInstanaSloAlertConfig = "instana_slo_alert_config"
+
+const (
+	//Slo Alert Config Field names for Terraform
+
+	SloAlertConfigFieldName                    = "name"
+	SloAlertConfigFieldDescription             = "description"
+	SloAlertConfigFieldSeverity 			   = "severity"
+	SloAlertConfigFieldTriggering 		   	   = "triggering"
+	SloAlertConfigFieldAlertType 			   = "alert_type"
+	SloAlertConfigFieldThreshold 			   = "threshold"
+	SloAlertConfigFieldThresholdOperator       = "threshold_operator"
+	SloAlertConfigFieldThresholdValue    	   = "threshold_value"
+	SloAlertConfigFieldSloIds                  = "slo_ids"
+	SloAlertConfigFieldAlertChannelIds         = "alert_channel_ids"
+	SloAlertConfigFieldTimeThreshold           = "time_threshold"
+	SloAlertConfigFieldTimeThresholdTimeWindow = "time_window"
+	SloAlertConfigFieldTimeThresholdExpiry     = "expiry"
+	SloAlertConfigFieldCustomPayloadFields     = "custom_payload_fields"
+	SloAlertConfigFieldEnabled                 = "enabled"
+
+	SloAlertConfigFieldBurnRateTimeWindows      = "burn_rate_time_windows"
+	SloAlertConfigFieldLongTimeWindow			= "long_time_window"
+	SloAlertConfigFieldShortTimeWindow			= "short_time_window"
+	SloAlertConfigFieldTimeWindowDuration		= "time_window_duration"
+	SloAlertConfigFieldTimeWindowDurationType	= "time_window_duration_type"
+
+
+	// Slo Alert Types for Terraform
+
+	SloAlertConfigStatus            = "status"
+	SloAlertConfigErrorBudget       = "error_budget"
+	SloAlertConfigBurnRate          = "burn_rate"
+
+
+)
+
+var sloAlertConfigAlertTypeKeys = []string{
+	"alert.0." + SloAlertConfigStatus,
+	"alert.0." + SloAlertConfigErrorBudget,
+	"alert.0." + SloAlertConfigBurnRate,
+}
+
+
+
+var (
+	//SloAlertConfigName schema field definition of instana_slo_alert_config field name
+	SloAlertConfigName = &schema.Schema{
+		Type:         schema.TypeString,
+		Required:     true,
+		ValidateFunc: validation.StringLenBetween(0, 256),
+		Description:  "The name of the SLO Alert config",
+	}
+
+	//SloAlertConfigDescription schema field definition of instana_slo_alert_config field description
+	SloAlertConfigDescription = &schema.Schema{
+		Type:        schema.TypeString,
+		Computed:    true,
+		Description: "The full name of the SLI config. The field is computed and contains the name which is sent to instana. The computation depends on the configured default_name_prefix and default_name_suffix at provider level",
+	}
+
+	//SloAlertConfigSeverity schema field definition of instana_slo_alert_config field severity
+	SloAlertConfigSeverity = &schema.Schema{
+		Type:        schema.TypeInt,
+		Required:     true,
+		Description: "The severity of the alert when triggered",
+	}
+
+	SloAlertConfigTriggering = &schema.Schema{
+		Type:        schema.TypeBool,
+		Optional:    true,
+		Default:     false,
+		Description: "Optional flag to indicate whether also an Incident is triggered or not. The default is false",
+	}
+
+	SloAlertConfigAlertType = &schema.Schema{
+		Type:         schema.TypeString,
+		Required:     true,
+		ValidateFunc: validation.StringInSlice([]string{"status", "errorBudget", "burnRate"}, true),
+		Description:  "What do you want to be alerted on? (Type of Smart Alert)",
+	}
+
+	SloAlertConfigThreshold = &schema.Schema{
+		Type:        schema.TypeList,  // Represents the "threshold" block
+		MinItems:    1,
+		MaxItems:    1,
+		Required:    true,
+		Description: "Indicates the type of violation of the defined threshold.",
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"operator": {
+					Type:         schema.TypeString,
+					Required:     true,
+					Description:  "The operator used to evaluate this rule.",
+					ValidateFunc: validation.StringInSlice([]string{">=", "<=", ">", "<", "==", "!="}, false),
+				},
+				"value": {
+					Type:        schema.TypeFloat,
+					Required:    true,
+					Description: "The threshold value for the alert condition.",
+				},
+			},
+		},
+	}
+	
+
+	SloAlertConfigSloIds = &schema.Schema{
+		Type:        schema.TypeList,
+		Required:    true,
+		Description: "The SLO IDs that are monitored",
+		MinItems:    1,
+		Elem: &schema.Schema{
+			Type: schema.TypeString,
+		},
+	}
+
+	SloAlertConfigAlertChannelIds = &schema.Schema{
+		Type:        schema.TypeList,
+		Required:    true,
+		Description: "The IDs of the Alert Channels",
+		MinItems:    1,
+		Elem: &schema.Schema{
+			Type: schema.TypeString,
+		},
+	}
+
+	SloAlertConfigTimeThreshold = &schema.Schema{
+		Type:        schema.TypeList,  // Represents the "time_threshold" block
+		MinItems:    1,
+		MaxItems:    1,
+		Required:    true,
+		Description: "Defines the time threshold for triggering and suppressing alerts.",
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"time_window": {
+					Type:        schema.TypeInt,
+					Required:    true,
+					Description: "The duration for which the condition must be violated for the alert to be triggered (in ms).",
+				},
+				"expiry": {
+					Type:        schema.TypeInt,
+					Required:    true,
+					Description: "The duration for which the condition must remain suppressed for the alert to end (in ms).",
+				},
+			},
+		},
+	}
+	
+
+
+
+
+)

--- a/instana/resource-slo-alert-config.go
+++ b/instana/resource-slo-alert-config.go
@@ -62,7 +62,7 @@ var (
 	//SloAlertConfigDescription schema field definition of instana_slo_alert_config field description
 	SloAlertConfigDescription = &schema.Schema{
 		Type:        schema.TypeString,
-		Computed:    true,
+		Required:    true,
 		Description: "The full name of the SLI config. The field is computed and contains the name which is sent to instana. The computation depends on the configured default_name_prefix and default_name_suffix at provider level",
 	}
 
@@ -132,7 +132,7 @@ var (
 	}
 
 	SloAlertConfigTimeThreshold = &schema.Schema{
-		Type:        schema.TypeList,  // Represents the "time_threshold" block
+		Type:        schema.TypeList,  
 		MinItems:    1,
 		MaxItems:    1,
 		Required:    true,
@@ -152,9 +152,115 @@ var (
 			},
 		},
 	}
+
+	// SloAlertConfigCustomPayloadFields = &schema.Schema{
+	// 	Type:        schema.TypeList,  
+	// 	Optional:    true,
+	// 	Description: "Custom payload fields to include additional metadata in the alert.",
+	// 	Elem: &schema.Resource{
+	// 		Schema: map[string]*schema.Schema{
+	// 			"key": {
+	// 				Type:        schema.TypeString,
+	// 				Required:    true,
+	// 				Description: "The key name for the custom payload field.",
+	// 			},
+	// 			"value": {
+	// 				Type:        schema.TypeString,
+	// 				Required:    true,
+	// 				Description: "The value associated with the custom payload field.",
+	// 			},
+	// 		},
+	// 	},
+	// }
 	
 
+	SloAlertConfigEnabled = &schema.Schema{
+		Type:        schema.TypeBool,
+		Optional:    true,
+		Default:     false,
+		Description: "Optional flag to indicate whether this Alert is Enabled",
+	}
 
-
-
+	SloAlertConfigBurnRateTimeWindows = &schema.Schema{
+		Type:        schema.TypeList,
+		MinItems:    1,
+		MaxItems:    1,
+		Required:    true,
+		Description: "Defines the burn rate time windows for evaluating alert conditions.",
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"long_time_window": {
+					Type:     schema.TypeList,
+					MinItems: 1,
+					MaxItems: 1,
+					Required: true,
+					Description: "Defines the long time window duration and type.",
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"duration": {
+								Type:        schema.TypeInt,
+								Required:    true,
+								Description: "The duration for the long time window.",
+							},
+							"duration_type": {
+								Type:         schema.TypeString,
+								Required:     true,
+								Description:  "The unit of time for the long time window duration (e.g., 'minute', 'hour').",
+								ValidateFunc: validation.StringInSlice([]string{"minute", "hour"}, false),
+							},
+						},
+					},
+				},
+				"short_time_window": {
+					Type:     schema.TypeList,
+					MinItems: 1,
+					MaxItems: 1,
+					Required: true,
+					Description: "Defines the short time window duration and type.",
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"duration": {
+								Type:        schema.TypeInt,
+								Required:    true,
+								Description: "The duration for the short time window.",
+							},
+							"duration_type": {
+								Type:         schema.TypeString,
+								Required:     true,
+								Description:  "The unit of time for the short time window duration (e.g., 'minute', 'hour').",
+								ValidateFunc: validation.StringInSlice([]string{"minute", "hour"}, false),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	
 )
+
+func NewSloAlertConfigResourceHandle() ResourceHandle[*restapi.SloConfig] {
+	Resource := &sloAlertConfigResource{
+		metaData: ResourceMetaData{
+			ResourceName: ResourceInstanaSloAlertConfig,
+			Schema: map[string]*schema.Schema{
+				SloAlertConfigFieldName:          	SloAlertConfigName,
+				SloAlertConfigFieldDescription:     SloAlertConfigDescription,
+				SloAlertConfigFieldSeverity:        SloAlertConfigSeverity,
+				SloAlertConfigFieldTriggering:   	SloAlertConfigTriggering,
+				SloAlertConfigFieldAlertType:   	SloAlertConfigAlertType,
+				SloAlertConfigFieldThreshold:    	SloAlertConfigThreshold,
+				SloAlertConfigFieldSloIds:  		SloAlertConfigSloIds,
+				SloAlertConfigFieldAlertChannelIds: SloAlertConfigAlertChannelIds,
+				SloAlertConfigFieldTimeThreshold:   SloAlertConfigTimeThreshold,
+				DefaultCustomPayloadFieldsName:  	buildCustomPayloadFields(),
+				SloAlertConfigFieldEnabled: 		SloAlertConfigEnabled,
+			},
+			SchemaVersion:    1,
+			CreateOnly:       false,
+			SkipIDGeneration: true,
+		},
+	}
+
+	return Resource
+}

--- a/instana/resource-slo-alert-config.go
+++ b/instana/resource-slo-alert-config.go
@@ -29,13 +29,11 @@ const (
 	SloAlertConfigFieldTimeThresholdTimeWindow = "time_window"
 	SloAlertConfigFieldTimeThresholdExpiry     = "expiry"
 	SloAlertConfigFieldEnabled                 = "enabled"
-
 	SloAlertConfigFieldBurnRateTimeWindows      = "burn_rate_time_windows"
 	SloAlertConfigFieldLongTimeWindow			= "long_time_window"
 	SloAlertConfigFieldShortTimeWindow			= "short_time_window"
 	SloAlertConfigFieldTimeWindowDuration		= "duration"
 	SloAlertConfigFieldTimeWindowDurationType	= "duration_type"
-
 
 	// Slo Alert Types for Terraform
 	SloAlertConfigStatus            = "status"
@@ -83,7 +81,7 @@ var (
 		Type:         schema.TypeString,
 		Required:     true,
 		ValidateFunc: validation.StringInSlice([]string{"status", "error_budget", "burn_rate"}, false),
-		Description:  "What do you want to be alerted on? (Type of Smart Alert)",
+		Description:  "What do you want to be alerted on? (Type of Smart Alert: status, error_budget, burn_rate)",
 	}
 
 	SloAlertConfigThreshold = &schema.Schema{
@@ -425,7 +423,7 @@ func (r *sloAlertConfigResource) UpdateState(d *schema.ResourceData, sloAlertCon
 		DefaultCustomPayloadFieldsName:   mapCustomPayloadFieldsToSchema(sloAlertConfig),
 		SloAlertConfigFieldEnabled:       sloAlertConfig.Enabled,
 		SloAlertConfigFieldBurnRateTimeWindows: burnRateTimeWindows,
-	}	
+	}
 
     d.SetId(sloAlertConfig.ID)
 
@@ -577,14 +575,14 @@ func (r *sloAlertConfigResource) MapStateToDataObject(d *schema.ResourceData) (*
 		BurnRateTimeWindows:   burnRateTimeWindows,
 	}
 
-payloadJSON, err := json.MarshalIndent(payload, "", "  ")
-if err != nil {
-	log.Printf("Error marshalling payload to JSON: %v", err)
-} else {
-	log.Printf("Payload sent to API: %s", string(payloadJSON))
-}
+	payloadJSON, err := json.MarshalIndent(payload, "", "  ")
+	if err != nil {
+		log.Printf("Error marshalling payload to JSON: %v", err)
+	} else {
+		log.Printf("Payload sent to API: %s", string(payloadJSON))
+	}
 
-return payload, nil
+	return payload, nil
 }
 
 func convertInterfaceSliceToStringSlice(input []interface{}) []string {

--- a/instana/restapi/Instana-api.go
+++ b/instana/restapi/Instana-api.go
@@ -35,6 +35,7 @@ type InstanaAPI interface {
 	AlertingConfigurations() RestResource[*AlertingConfiguration]
 	SliConfigs() RestResource[*SliConfig]
 	SloConfigs() RestResource[*SloConfig]
+	SloAlertConfigs() RestResource[*SloAlertConfig]
 	WebsiteMonitoringConfig() RestResource[*WebsiteMonitoringConfig]
 	WebsiteAlertConfig() RestResource[*WebsiteAlertConfig]
 	InfraAlertConfig() RestResource[*InfraAlertConfig]
@@ -100,6 +101,10 @@ func (api *baseInstanaAPI) SliConfigs() RestResource[*SliConfig] {
 
 func (api *baseInstanaAPI) SloConfigs() RestResource[*SloConfig] {
 	return NewCreatePOSTUpdatePUTRestResource(SloConfigResourcePath, NewDefaultJSONUnmarshaller(&SloConfig{}), api.client)
+}
+
+func (api *baseInstanaAPI) SloAlertConfigs() RestResource[*SloAlertConfig] {
+	return NewCreatePOSTUpdatePUTRestResource(SloAlertConfigResourcePath, NewDefaultJSONUnmarshaller(&SloAlertConfig{}), api.client)
 }
 
 func (api *baseInstanaAPI) WebsiteMonitoringConfig() RestResource[*WebsiteMonitoringConfig] {

--- a/instana/restapi/Instana-api.go
+++ b/instana/restapi/Instana-api.go
@@ -35,7 +35,7 @@ type InstanaAPI interface {
 	AlertingConfigurations() RestResource[*AlertingConfiguration]
 	SliConfigs() RestResource[*SliConfig]
 	SloConfigs() RestResource[*SloConfig]
-	SloAlertConfigs() RestResource[*SloAlertConfig]
+	SloAlertConfig() RestResource[*SloAlertConfig]
 	WebsiteMonitoringConfig() RestResource[*WebsiteMonitoringConfig]
 	WebsiteAlertConfig() RestResource[*WebsiteAlertConfig]
 	InfraAlertConfig() RestResource[*InfraAlertConfig]
@@ -103,7 +103,7 @@ func (api *baseInstanaAPI) SloConfigs() RestResource[*SloConfig] {
 	return NewCreatePOSTUpdatePUTRestResource(SloConfigResourcePath, NewDefaultJSONUnmarshaller(&SloConfig{}), api.client)
 }
 
-func (api *baseInstanaAPI) SloAlertConfigs() RestResource[*SloAlertConfig] {
+func (api *baseInstanaAPI) SloAlertConfig() RestResource[*SloAlertConfig] {
 	return NewCreatePOSTUpdatePUTRestResource(SloAlertConfigResourcePath, NewDefaultJSONUnmarshaller(&SloAlertConfig{}), api.client)
 }
 

--- a/instana/restapi/Instana-api.go
+++ b/instana/restapi/Instana-api.go
@@ -104,7 +104,7 @@ func (api *baseInstanaAPI) SloConfigs() RestResource[*SloConfig] {
 }
 
 func (api *baseInstanaAPI) SloAlertConfig() RestResource[*SloAlertConfig] {
-	return NewCreatePOSTUpdatePUTRestResource(SloAlertConfigResourcePath, NewDefaultJSONUnmarshaller(&SloAlertConfig{}), api.client)
+	return NewCreatePOSTUpdatePOSTRestResource(SloAlertConfigResourcePath, NewDefaultJSONUnmarshaller(&SloAlertConfig{}), api.client)
 }
 
 func (api *baseInstanaAPI) WebsiteMonitoringConfig() RestResource[*WebsiteMonitoringConfig] {

--- a/instana/restapi/slo-alert-config-api.go
+++ b/instana/restapi/slo-alert-config-api.go
@@ -24,6 +24,7 @@ type SloAlertConfig struct {
 	SloIds              []string                 	`json:"sloIds"`
 	AlertChannelIds     []string                  	`json:"alertChannelIds"`
     CustomerPayloadFields []CustomPayloadField[any] `json:"customPayloadFields"`
+	BurnRateTimeWindows *BurnRateTimeWindows `json:"burnRateTimeWindows,omitempty"`
 }
 
 type SloAlertRule struct {
@@ -40,6 +41,16 @@ type SloAlertThreshold struct {
 type SloAlertTimeThreshold struct {
 	Timewindow 	int `json:"timewindow"`
 	Expiry     	int `json:"expiry"`
+}
+
+type BurnRateTimeWindows struct {
+    LongTimeWindow  TimeWindow `json:"longTimeWindow"`
+    ShortTimeWindow TimeWindow `json:"shortTimeWindow"`
+}
+
+type TimeWindow struct {
+    TimeWindowDuration     int    `json:"duration"`
+    TimeWindowDurationType string `json:"durationType"`
 }
 
 // GetIDForResourcePath implementation of the interface InstanaDataObject

--- a/instana/restapi/slo-alert-config-api.go
+++ b/instana/restapi/slo-alert-config-api.go
@@ -12,32 +12,40 @@ const (
 
 // SloAlertConfig represents the REST resource of SLO Alert Configuration at Instana
 type SloAlertConfig struct {
-	ID          		string      `json:"id"`
-	Name        		string      `json:"name"`
-	Description 		string     	`json:"description"`
-	Severity    		int      	`json:"severity"`
-	Triggering  		bool      	`json:"triggering"`
-	Enabled    			bool     	`json:"enabled"`
-	AlertType			string		`json:"alertType"`
-	Threshold   		interface{} `json:"threshold"`
-	TimeThreshold  		interface{} `json:"timeThreshold"`
-	SloIds      		[]string    `json:"sloIds"`
-	AlertChannelIds 	[]string 	`json:"alertChannelIds"`
-	CustomPayloadFields []string 	`json:"customPayloadFields"`
+	ID          			string              		`json:"id"`
+	Name        			string              		`json:"name"`
+	Description 			string              		`json:"description"`
+	Severity    			int                 		`json:"severity"`
+	Triggering  			bool                		`json:"triggering"`
+	Enabled    				bool                		`json:"enabled"`
+	AlertType				string              		`json:"alertType"`
+	Threshold   			SloAlertThreshold   		`json:"threshold"` 
+	TimeThreshold  			SloAlertTimeThreshold 		`json:"timeThreshold"` 
+	SloIds      			[]string          	  		`json:"sloIds"`
+	AlertChannelIds 		[]string            		`json:"alertChannelIds"`
+	CustomerPayloadFields 	[]CustomPayloadField[any]	`json:"customPayloadFields"`
 }
 
 type SloAlertThreshold struct {
-	Operator     string        `json:"operator"`
-	Value 		 float64 	   `json:"value"`
+	Operator string  `json:"operator"`
+	Value    float64 `json:"value"`
 }
 
 type SloAlertTimeThreshold struct {
-	Timewindow      int        `json:"timewindow"`
-	expiry			int    	   `json:"expiry"`
+	Timewindow 	int `json:"timewindow"`
+	Expiry     	int `json:"expiry"`
 }
 
 // GetIDForResourcePath implementation of the interface InstanaDataObject
 func (s *SloAlertConfig) GetIDForResourcePath() string {
 	fmt.Fprintln(os.Stderr, ">> GetIDForResourcePath: "+s.ID)
 	return s.ID
+}
+
+func (config *SloAlertConfig) GetCustomerPayloadFields() []CustomPayloadField[any] {
+	return config.CustomerPayloadFields
+}
+
+func (config *SloAlertConfig) SetCustomerPayloadFields(fields []CustomPayloadField[any]) {
+	config.CustomerPayloadFields = fields
 }

--- a/instana/restapi/slo-alert-config-api.go
+++ b/instana/restapi/slo-alert-config-api.go
@@ -12,17 +12,17 @@ const (
 
 // SloAlertConfig represents the REST resource of SLO Alert Configuration at Instana
 type SloAlertConfig struct {
-    ID                  string                  `json:"id"`
-    Name                string                  `json:"name"`
-    Description         string                  `json:"description"`
-    Severity            int                     `json:"severity"`
-    Triggering          bool                    `json:"triggering"`
-    Enabled             bool                    `json:"enabled"`
-    Rule                SloAlertRule            `json:"rule"` 
-    Threshold           SloAlertThreshold       `json:"threshold"`
-    TimeThreshold       SloAlertTimeThreshold   `json:"timeThreshold"`
-    SloIds              []string                `json:"sloIds"`
-    AlertChannelIds     []string                `json:"alertChannelIds"`
+	ID                  string                    	`json:"id"`
+	Name                string                    	`json:"name"`
+	Description         string                    	`json:"description"`
+	Severity            int                       	`json:"severity"`
+	Triggering          bool                      	`json:"triggering"`
+	Enabled             bool                      	`json:"enabled"`
+	Rule                SloAlertRule              	`json:"rule"`
+	Threshold           SloAlertThreshold         	`json:"threshold"`
+	TimeThreshold       SloAlertTimeThreshold     	`json:"timeThreshold"`
+	SloIds              []string                 	`json:"sloIds"`
+	AlertChannelIds     []string                  	`json:"alertChannelIds"`
     CustomerPayloadFields []CustomPayloadField[any] `json:"customPayloadFields"`
 }
 

--- a/instana/restapi/slo-alert-config-api.go
+++ b/instana/restapi/slo-alert-config-api.go
@@ -24,5 +24,20 @@ type SloAlertConfig struct {
 	SloIds      		[]string    `json:"sloIds"`
 	AlertChannelIds 	[]string 	`json:"alertChannelIds"`
 	CustomPayloadFields []string 	`json:"customPayloadFields"`
+}
 
+type SloAlertThreshold struct {
+	Operator     string        `json:"operator"`
+	Value 		 float64 	   `json:"value"`
+}
+
+type SloAlertTimeThreshold struct {
+	Timewindow      int        `json:"timewindow"`
+	expiry			int    	   `json:"expiry"`
+}
+
+// GetIDForResourcePath implementation of the interface InstanaDataObject
+func (s *SloAlertConfig) GetIDForResourcePath() string {
+	fmt.Fprintln(os.Stderr, ">> GetIDForResourcePath: "+s.ID)
+	return s.ID
 }

--- a/instana/restapi/slo-alert-config-api.go
+++ b/instana/restapi/slo-alert-config-api.go
@@ -12,18 +12,23 @@ const (
 
 // SloAlertConfig represents the REST resource of SLO Alert Configuration at Instana
 type SloAlertConfig struct {
-	ID          			string              		`json:"id"`
-	Name        			string              		`json:"name"`
-	Description 			string              		`json:"description"`
-	Severity    			int                 		`json:"severity"`
-	Triggering  			bool                		`json:"triggering"`
-	Enabled    				bool                		`json:"enabled"`
-	AlertType				string              		`json:"alertType"`
-	Threshold   			SloAlertThreshold   		`json:"threshold"` 
-	TimeThreshold  			SloAlertTimeThreshold 		`json:"timeThreshold"` 
-	SloIds      			[]string          	  		`json:"sloIds"`
-	AlertChannelIds 		[]string            		`json:"alertChannelIds"`
-	CustomerPayloadFields 	[]CustomPayloadField[any]	`json:"customPayloadFields"`
+    ID                  string                  `json:"id"`
+    Name                string                  `json:"name"`
+    Description         string                  `json:"description"`
+    Severity            int                     `json:"severity"`
+    Triggering          bool                    `json:"triggering"`
+    Enabled             bool                    `json:"enabled"`
+    Rule                SloAlertRule            `json:"rule"` 
+    Threshold           SloAlertThreshold       `json:"threshold"`
+    TimeThreshold       SloAlertTimeThreshold   `json:"timeThreshold"`
+    SloIds              []string                `json:"sloIds"`
+    AlertChannelIds     []string                `json:"alertChannelIds"`
+    CustomerPayloadFields []CustomPayloadField[any] `json:"customPayloadFields"`
+}
+
+type SloAlertRule struct {
+    AlertType string `json:"alertType"`
+    Metric    string `json:"metric"`
 }
 
 type SloAlertThreshold struct {

--- a/instana/restapi/slo-alert-config-api.go
+++ b/instana/restapi/slo-alert-config-api.go
@@ -1,0 +1,28 @@
+package restapi
+
+import (
+	"fmt"
+	"os"
+)
+
+const (
+	//SloAlertConfigResourcePath path to slo alert config resource of Instana RESTful API
+	SloAlertConfigResourcePath = EventSettingsBasePath + "/global-alert-configs/service-levels"
+)
+
+// SloAlertConfig represents the REST resource of SLO Alert Configuration at Instana
+type SloAlertConfig struct {
+	ID          		string      `json:"id"`
+	Name        		string      `json:"name"`
+	Description 		string     	`json:"description"`
+	Severity    		int      	`json:"severity"`
+	Triggering  		bool      	`json:"triggering"`
+	Enabled    			bool     	`json:"enabled"`
+	AlertType			string		`json:"alertType"`
+	Threshold   		interface{} `json:"threshold"`
+	TimeThreshold  		interface{} `json:"timeThreshold"`
+	SloIds      		[]string    `json:"sloIds"`
+	AlertChannelIds 	[]string 	`json:"alertChannelIds"`
+	CustomPayloadFields []string 	`json:"customPayloadFields"`
+
+}

--- a/instana/restapi/slo-alert-config-api.go
+++ b/instana/restapi/slo-alert-config-api.go
@@ -27,8 +27,9 @@ type SloAlertConfig struct {
 }
 
 type SloAlertThreshold struct {
-	Operator string  `json:"operator"`
-	Value    float64 `json:"value"`
+    Type     string  `json:"type"`     
+    Operator string  `json:"operator"`
+    Value    float64 `json:"value"`
 }
 
 type SloAlertTimeThreshold struct {

--- a/mocks/Instana-api_mocks.go
+++ b/mocks/Instana-api_mocks.go
@@ -202,6 +202,20 @@ func (mr *MockInstanaAPIMockRecorder) SloConfigs() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SloConfigs", reflect.TypeOf((*MockInstanaAPI)(nil).SloConfigs))
 }
 
+// SloAlertConfigs mocks base method.
+func (m *MockInstanaAPI) SloAlertConfigs() restapi.RestResource[*restapi.SloAlertConfig] {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SloAlertConfigs")
+	ret0, _ := ret[0].(restapi.RestResource[*restapi.SloAlertConfig])
+	return ret0
+}
+
+// SloAlertConfigs indicates an expected call of SloConfigs.
+func (mr *MockInstanaAPIMockRecorder) SloAlertConfigs() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SloAlertConfigs", reflect.TypeOf((*MockInstanaAPI)(nil).SloAlertConfigs))
+}
+
 // SyntheticLocation mocks base method.
 func (m *MockInstanaAPI) SyntheticLocation() restapi.ReadOnlyRestResource[*restapi.SyntheticLocation] {
 	m.ctrl.T.Helper()

--- a/mocks/Instana-api_mocks.go
+++ b/mocks/Instana-api_mocks.go
@@ -202,18 +202,18 @@ func (mr *MockInstanaAPIMockRecorder) SloConfigs() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SloConfigs", reflect.TypeOf((*MockInstanaAPI)(nil).SloConfigs))
 }
 
-// SloAlertConfigs mocks base method.
-func (m *MockInstanaAPI) SloAlertConfigs() restapi.RestResource[*restapi.SloAlertConfig] {
+// SloAlertConfig mocks base method.
+func (m *MockInstanaAPI) SloAlertConfig() restapi.RestResource[*restapi.SloAlertConfig] {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SloAlertConfigs")
+	ret := m.ctrl.Call(m, "SloAlertConfig")
 	ret0, _ := ret[0].(restapi.RestResource[*restapi.SloAlertConfig])
 	return ret0
 }
 
-// SloAlertConfigs indicates an expected call of SloConfigs.
-func (mr *MockInstanaAPIMockRecorder) SloAlertConfigs() *gomock.Call {
+// SloAlertConfig indicates an expected call of SloConfigs.
+func (mr *MockInstanaAPIMockRecorder) SloAlertConfig() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SloAlertConfigs", reflect.TypeOf((*MockInstanaAPI)(nil).SloAlertConfigs))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SloAlertConfig", reflect.TypeOf((*MockInstanaAPI)(nil).SloAlertConfig))
 }
 
 // SyntheticLocation mocks base method.


### PR DESCRIPTION
This PR introduces support for SLO smart alerts in the Instana Terraform provider by implementing the `instana_slo_alert_config` resource. It enables creation and management of `status`, `error_budget`, and `burn_rate` alert types, integrating with Instana’s SLO alert configuration API.